### PR TITLE
added build configuration for Darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ tags
 *.app
 *.i*86
 *.x86_64
+*.darwin-i*86
+*.darwin-x86_64
 *.hex
 
 # Debug files

--- a/Marlin/SConstruct
+++ b/Marlin/SConstruct
@@ -5,6 +5,20 @@ else:
   debug_flags = '-O2'
 
 env = Environment(
+    CXX='clang',
+    CPPFLAGS= '-Wall -std=gnu++14 -MMD ' + debug_flags,
+    LINKFLAGS='-Wall -std=gnu++14 -lstdc++ ' + debug_flags)
+env.VariantDir('darwin-x86_64', 'src/module', duplicate=0)
+env.Program('darwin-x86_64/marlin-calc.darwin-x86_64', ['darwin-x86_64/planner.cpp', 'darwin-x86_64/calc.cpp'])
+
+env = Environment(
+    CXX='clang',
+    CPPFLAGS= '-Wall -std=gnu++14 -m32 -MMD ' + debug_flags,
+    LINKFLAGS='-Wall -std=gnu++14 -m32 -lstdc++ ' + debug_flags)
+env.VariantDir('darwin-i686', 'src/module', duplicate=0)
+env.Program('darwin-i686/marlin-calc.darwin-i686', ['darwin-i686/planner.cpp', 'darwin-i686/calc.cpp'])
+
+env = Environment(
     CXX='g++',
     CPPFLAGS= '-Wall -static -std=gnu++11 -MMD ' + debug_flags,
     LINKFLAGS='-Wall -static -std=gnu++11 ' + debug_flags)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 To build:
 
-`cd Marlin/Marlin && make -f Makefile.calc`
+`cd Marlin/Marlin && scons`
+
+To build a specific architecture, for example with x86_64:
+
+`cd Marlin/Marlin && scons x86_64/marlin-calc.x86_64`
 
 Original `README.md` below.
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Tweaks to allow building on Mac, tested with Xcode 9.4.1. Changes required were:

- Bump standard from C++11 to C++14. In C++11 `void` is not a literal type, so `constexpr` functions may not return it, and compilation of `NOLESS()` and friends fails. GCC relaxed this requirement even with `-std=gnu++11`, but Clang did not.
- Explicitly link `libstdc++`.
- Remove static linkage. Apple does not ship a static `libstdc++` and so the executable must use the system-provided dylibs.

### Benefits

Allows building for Mac

### Related Issues

[OctoPrint-PrintTimeGenius #72](https://github.com/eyal0/OctoPrint-PrintTimeGenius/issues/72)
